### PR TITLE
Feat/compare table with different name

### DIFF
--- a/rowiterator/scan_iterator.go
+++ b/rowiterator/scan_iterator.go
@@ -55,11 +55,11 @@ func NewScanIterator(
 
 	// hard coded mapping of renamed tables when compare row by row
 	mapping := make(map[string]string)
-	mapping["cards"] = "cards_payment_methods"
-	mapping["orig_table"] = "renamed_table"
-	val, ok := mapping[table.Name.Table.String()]
+	mapping["public.cards"] = "public.cards_payment_methods"
+	mapping["public.orig_table"] = "public.renamed_table"
+	val, ok := mapping[table.Name.SafeString()]
 	if ok && conn.ID() == "target" {
-		table.Name.Table = tree.Name(val)
+		table.Name.Table = tree.Name(strings.TrimPrefix(val, "public."))
 	}
 
 	it := &scanIterator{

--- a/rowiterator/scan_iterator.go
+++ b/rowiterator/scan_iterator.go
@@ -52,6 +52,16 @@ func NewScanIterator(
 			return nil, errors.Wrapf(err, "Error initializing type oid %d", typOID)
 		}
 	}
+
+	// hard coded mapping of renamed tables when compare row by row
+	mapping := make(map[string]string)
+	mapping["cards"] = "cards_payment_methods"
+	mapping["orig_table"] = "renamed_table"
+	val, ok := mapping[table.Name.Table.String()]
+	if ok && conn.ID() == "target" {
+		table.Name.Table = tree.Name(val)
+	}
+
 	it := &scanIterator{
 		conn:          conn,
 		table:         table,
@@ -128,7 +138,7 @@ func (it *scanIterator) nextPage(ctx context.Context) {
 			case *dbconn.PGConn:
 				newRows, err := conn.Query(ctx, q, args...)
 				if err != nil {
-					return nil, errors.Wrapf(err, "error getting rows for table %s.%s from %s", it.table.Schema, it.table.Table.Name, it.conn.ID)
+					return nil, errors.Wrapf(err, "error getting rows for table %s.%s from %s", it.table.Schema, it.table.Table.Name, it.conn.ID())
 				}
 				currRows = &pgRows{
 					Rows:    newRows,

--- a/verify/dbverify/dbverify.go
+++ b/verify/dbverify/dbverify.go
@@ -169,7 +169,19 @@ func compare(iterators [2]tableVerificationIterator) Result {
 		// tables.
 		compareVal := 1
 		if !nonTruthIterator.done() {
-			compareVal = nonTruthIterator.curr().Compare(truthIterator.curr())
+			//hard codeed mapping of renamed tables
+			mapping := make(map[string]string)
+			mapping["public.cards"] = "public.cards_payment_methods"
+			mapping["public.orig_table"] = "public.renamed_table"
+			if val, ok := mapping[truthIterator.curr().String()]; ok {
+				if val == nonTruthIterator.curr().String() {
+					compareVal = 0
+				} else {
+					compareVal = nonTruthIterator.curr().Compare(truthIterator.curr())
+				}
+			} else {
+				compareVal = nonTruthIterator.curr().Compare(truthIterator.curr())
+			}
 		}
 		switch compareVal {
 		case -1:

--- a/verify/rowverify/live_reverifier.go
+++ b/verify/rowverify/live_reverifier.go
@@ -2,6 +2,7 @@ package rowverify
 
 import (
 	"context"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -165,16 +166,16 @@ func newLiveReverifier(
 					Msgf("live reverifying primary keys")
 				// hard coded mapping of renamed tables when compare row by row
 				mapping := make(map[string]string)
-				mapping["cards"] = "cards_payment_methods"
-				mapping["orig_table"] = "renamed_table"
+				mapping["public.cards"] = "public.cards_payment_methods"
+				mapping["public.orig_table"] = "public.renamed_table"
 				var iterators [2]rowiterator.Iterator
 				for i, conn := range conns {
 					newTableName := table.Name
-					val, ok := mapping[table.Name.Table.String()]
+					val, ok := mapping[table.Name.SafeString()]
 					if ok && conn.ID() == "target" {
 						newTableName = dbtable.Name{
 							Schema: table.Name.Schema,
-							Table:  tree.Name(val),
+							Table:  tree.Name(strings.TrimPrefix(val, "public.")),
 						}
 					}
 					iterators[i] = rowiterator.NewPointLookupIterator(

--- a/verify/tableverify/tableverify.go
+++ b/verify/tableverify/tableverify.go
@@ -25,7 +25,6 @@ func VerifyCommonTables(
 	ctx context.Context, conns dbconn.OrderedConns, allTables [][2]dbtable.DBTable,
 ) ([]Result, error) {
 	var ret []Result
-
 	for _, cmpTables := range allTables {
 		pkCols, err := getPrimaryKeysForTables(ctx, conns, cmpTables)
 		if err != nil {


### PR DESCRIPTION
#### Context
It's a hacky work around to compare the data within different table name. Don't sync it back to cockroachDB team repo. 
- hard coded multiple hashmap to map the table name between source and target table. 
- I have tested it with `live-verify` and `verify` command with `--table-filter` and managed to compare the table
- It's a hacky work around and just enough to help us. If it work, I will adjust the code to make it more flexible to use. 
